### PR TITLE
fix: correct description of reconnecting and reconnect_attempt events

### DIFF
--- a/source/docs/client-api.md
+++ b/source/docs/client-api.md
@@ -355,13 +355,15 @@ Fired upon a successful reconnection.
 
 ## Event: 'reconnect_attempt'
 
+  - `attempt` _(Number)_ reconnection attempt number
+
 Fired upon an attempt to reconnect.
 
 ## Event: 'reconnecting'
 
   - `attempt` _(Number)_ reconnection attempt number
 
-Fired upon a successful reconnection.
+Fired upon an attempt to reconnect.
 
 ## Event: 'reconnect_error'
 


### PR DESCRIPTION
Both `reconnecting` and `reconnect_attempt` are exactly the same thing.

This PR corrects descriptions of that events on top of client api docs page:

https://socket.io/docs/client-api/#Event-%E2%80%98reconnect-attempt%E2%80%99